### PR TITLE
fix: match NuGet version to heroicons on icon sync

### DIFF
--- a/kanban/done/003-match-nuget-version-to-heroicons-upstream-on-sync.md
+++ b/kanban/done/003-match-nuget-version-to-heroicons-upstream-on-sync.md
@@ -1,0 +1,46 @@
+# Match NuGet version to heroicons upstream on sync
+
+## Description
+
+Fix `dev update-icons` versioning so package identity tracks tailwindlabs/heroicons
+exactly on sync, and document TW-only fix releases (`X.Y.Z-tw.N`).
+
+## Requirements
+
+- On icon sync, set `<Version>` to the upstream heroicons version (e.g. `2.2.0`), not patch++
+- Extract upstream pin correctly from clean, `+metadata`, and `-tw.N` / `-update.N` forms
+- Do not invent disconnected versions like `2.0.19` while still on heroicons 2.0.18
+- Document policy for humans (releases.md + Design region)
+
+## Checklist
+
+- [x] Replace `BumpPackageVersion` patch++ with clean upstream match
+- [x] Harden `ExtractUpstreamVersion` for `-tw.N` / `-update.N`
+- [x] Pack path uses NuGet identity (strip `+` metadata for `.nupkg` name)
+- [x] Document policy in Design region and releases.md
+- [ ] Follow-up (separate): sync icons to 2.2.0 and publish as 2.2.0
+
+## Notes
+
+Latest upstream is 2.2.0; we are still content-pinned at 2.0.18 with NuGet 2.0.19
+(historical screwup). This task only fixes the bumber/policy so the next sync ships
+the correct identity.
+
+## Session
+
+- Implementation: grok (2026-08-12)
+
+## Results
+
+### What changed
+- `BumpPackageVersion` now returns the upstream heroicons version unchanged (match).
+- `ExtractUpstreamVersion` supports `+pin` and prerelease bases (`2.2.0-tw.1` → `2.2.0`).
+- Pack looks for `timewarp-heroicons.{identity}.nupkg` without `+` metadata.
+- Policy documented in command Design region and `releases.md`.
+
+### How to validate
+- Smoke: `dotnet run --file tools/dev-cli/dev.cs -- update-icons --help` succeeds.
+- Code review: `BumpPackageVersion(_, "2.2.0")` must return `"2.2.0"`; extract from
+  `2.2.0-tw.1` and `2.0.19+2.0.18` yields `2.2.0` / `2.0.18`.
+- Does **not** publish 2.2.0 by itself — that is a separate sync+release step.
+

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,11 @@
 # Releases
 
+Versioning: NuGet identity **matches** [heroicons](https://github.com/tailwindlabs/heroicons)
+when we sync (`2.2.0` = heroicons 2.2.0). TW-only fixes without a new heroicons
+release use a prerelease suffix on that base (`2.2.0-tw.1`), not a disconnected
+patch and not `+` metadata alone (metadata is not part of the NuGet identity).
+Historical note: `2.0.19` was a TW rework of heroicons **2.0.18**, not an upstream tag.
+
 ## 2.0.19+2.0.18
 
 * Update to optimized version 2.0.18

--- a/tools/dev-cli/endpoints/update-icons-command.cs
+++ b/tools/dev-cli/endpoints/update-icons-command.cs
@@ -2,8 +2,17 @@
 // Syncs Blazor icon components from upstream tailwindlabs/heroicons releases
 #endregion
 #region Design
-// Compares the pinned heroicons version in source/Directory.Build.props with the latest GitHub
-// release, regenerates components when stale, optionally commits/pushes and publishes to NuGet
+// Version policy (this package is NOT a normal independent TimeWarp line):
+//   - When we sync to heroicons X.Y.Z, NuGet identity MUST be X.Y.Z (match source).
+//   - TW-only fix without a new heroicons release: SemVer prerelease on that base,
+//     e.g. 2.2.0-tw.1 (historical: 2.0.12-update.1). Never invent a disconnected
+//     patch like 2.0.19 while still on heroicons 2.0.18.
+//   - Optional +metadata may record the pin (2.2.0-tw.1+2.2.0) but + alone cannot
+//     distinguish NuGet packages — only the identity before + ships to nuget.org.
+//
+// Flow: read props Version → extract upstream pin → compare to latest GitHub
+// heroicons release → if stale, clone optimized SVGs, transform to Razor, set
+// Version = upstream (clean match), update releases.md, build, optional push/publish.
 #endregion
 
 namespace DevCli.Commands;
@@ -102,23 +111,31 @@ internal sealed class UpdateIconsCommand : ICommand<Unit>
       return version;
     }
 
+    // Upstream pin from Version: prefer +metadata; else strip prerelease (2.2.0-tw.1 → 2.2.0).
     private static string ExtractUpstreamVersion(string version)
     {
       int plus = version.IndexOf('+');
-      return plus >= 0 ? version[(plus + 1)..] : version;
-    }
-
-    private static string BumpPackageVersion(string currentVersion, string upstreamVersion)
-    {
-      string packagePart = currentVersion.Split('+')[0];
-      string[] parts = packagePart.Split('.');
-      if (parts.Length < 3 || !int.TryParse(parts[^1], out int patch))
+      if (plus >= 0)
       {
-        return $"{upstreamVersion}+{upstreamVersion}";
+        return version[(plus + 1)..];
       }
 
-      parts[^1] = (patch + 1).ToString();
-      return $"{string.Join('.', parts)}+{upstreamVersion}";
+      // TW-only re-ship: 2.2.0-tw.1 / 2.0.12-update.1 still track base X.Y.Z
+      int dash = version.IndexOf('-');
+      if (dash >= 0)
+      {
+        return version[..dash];
+      }
+
+      return version;
+    }
+
+    // On icon sync, NuGet version = heroicons version (no patch++ drift).
+    // TW-only revisions are not produced here — hand-edit to e.g. 2.2.0-tw.1.
+    private static string BumpPackageVersion(string currentVersion, string upstreamVersion)
+    {
+      _ = currentVersion;
+      return upstreamVersion;
     }
 
     private static async Task<string> FetchLatestHeroiconsVersionAsync(CancellationToken ct)
@@ -298,7 +315,9 @@ internal sealed class UpdateIconsCommand : ICommand<Unit>
         .RunAsync(ct);
       if (exitCode != 0) return Fail(exitCode);
 
-      string packagePath = Path.Combine(artifactsDir, $"timewarp-heroicons.{version}.nupkg");
+      // Pack uses NuGet identity (metadata after + is not in the file name).
+      string nugetIdentity = version.Split('+')[0];
+      string packagePath = Path.Combine(artifactsDir, $"timewarp-heroicons.{nugetIdentity}.nupkg");
       if (!File.Exists(packagePath))
       {
         Terminal.WriteErrorLine($"Package not found: {packagePath}".Red());


### PR DESCRIPTION
## Summary
- Aligns package versioning with the product model: **NuGet identity = heroicons version** when `dev update-icons` syncs.
- Replaces broken `patch++` bumber (which would have shipped `2.0.20+2.2.0` instead of `2.2.0`).
- TW-only fixes without a new upstream: use `2.2.0-tw.1` (or historical `-update.N`); not disconnected `2.0.x`, not `+` metadata alone.
- Documents policy in `releases.md` and the command Design region.
- Historical note: NuGet `2.0.19` was a TW rework of heroicons **2.0.18**, not an upstream tag.

## Not in this PR
- Does **not** sync icons or publish **2.2.0** yet. Next step after merge: successful `update-icons` → content + version `2.2.0` → publish.

## Test plan
- [x] `dotnet run --file tools/dev-cli/dev.cs -- update-icons --help`
- [ ] CI green
- [ ] Code review of `BumpPackageVersion` / `ExtractUpstreamVersion`